### PR TITLE
Replace CommonJS export with ES6 export

### DIFF
--- a/src/store/configure-store.js
+++ b/src/store/configure-store.js
@@ -1,12 +1,11 @@
 /* eslint global-require: 0 */
 
-let configureStore;
-
-if (process.env.NODE_ENV === 'production') {
-  configureStore = require('./configure-store.prod');
-} else {
-  configureStore = require('./configure-store.dev');
+export default function configureStore() {
+  let store;
+  if (process.env.NODE_ENV === 'production') {
+    store = require('./configure-store.prod');
+  } else {
+    store = require('./configure-store.dev');
+  }
+  return store;
 }
-
-
-module.exports = configureStore;


### PR DESCRIPTION
I have noticed that you use ES6 modules, but in src/store/configure-store.js file was used CommonJS export. Even tho eslint-plugin-import wasn't throwing any warnings for [no-commonjs](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-commonjs.md) I have changed it to use ES6 syntax for consistency. 
And because of [no-mutable-exports](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-mutable-exports.md) configure-store.js now exports function that return configured store.